### PR TITLE
Adopt numpy-quaternion operations

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,6 +10,7 @@ requires-python = ">=3.11"
 dependencies = [
     "matplotlib>=3.10.6",
     "numpy>=2.3.3",
+    "numpy-quaternion>=2023.0.6",
 ]
 
 [project.scripts]


### PR DESCRIPTION
## Summary
- replace the hand-rolled quaternion helpers with numpy-quaternion utilities for rotating body and earth vectors
- update the 6-DoF integrator to normalize, multiply, and propagate the attitude using numpy-quaternion objects
- declare numpy-quaternion as a runtime dependency so the specialized dtype is available

## Testing
- python -m compileall src

------
https://chatgpt.com/codex/tasks/task_e_68e153a59648832b9ad9208008327bdb