### PR TITLE
Add wake vortex model and induced roll coupling

### DIFF
--- a/src/formation_flight_pid_control/params.py
+++ b/src/formation_flight_pid_control/params.py
@@ -7,11 +7,11 @@ from dataclasses import dataclass
 class Params:
     mtom: float = 16.0
     gravity: float = 9.81
-    S_wing_ref_area: float = 0.6
-    c_bar: float = 0.5
+    S_wing_ref_area: float = 12.0
+    c_bar: float = 1.2
     x_ac: float = 0.2
     x_cg: float = 0.15
-    b_span: float = 2.4
+    b_span: float = 10.0
     AR: float = b_span / c_bar
     rho: float = 1.225
     e_const: float = 0.6
@@ -20,7 +20,7 @@ class Params:
     thrust_max: float = 35.0
 
     CL0: float = 0.0
-    CL_alpha: float = 5.0
+    CL_alpha: float = 5.5
     CY_beta: float = -0.9
     CD0: float = 0.01
     CMAC: float = 0.05
@@ -41,3 +41,12 @@ class Params:
 
     v_eps: float = 1e-3
     cth_eps: float = 1e-3
+
+    # --- Wake / vortex model params ---
+    wake_enable: bool = True
+    wake_core_radius: float = 2.0
+    wake_decay_time: float = 8.0
+    wake_segment_length: float = 5.0
+    wake_history_len: int = 80
+    wake_gamma_scale: float = 1.0
+    wake_axial_decay_len: float = 150.0

--- a/src/formation_flight_pid_control/wake.py
+++ b/src/formation_flight_pid_control/wake.py
@@ -1,0 +1,65 @@
+"""Wake vortex data structures and helper functions."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+import numpy as np
+
+
+@dataclass
+class VortexBead:
+    pos_w: np.ndarray
+    gamma: float
+    age: float
+
+
+@dataclass
+class TipWake:
+    beads: list[VortexBead] = field(default_factory=list)
+
+
+@dataclass
+class AircraftWake:
+    left: TipWake = field(default_factory=TipWake)
+    right: TipWake = field(default_factory=TipWake)
+
+
+def unit(v: np.ndarray) -> np.ndarray:
+    norm = float(np.linalg.norm(v))
+    if norm < 1e-9:
+        return np.zeros_like(v)
+    return v / norm
+
+
+def lamb_oseen_induced_vel_at_point(
+    point_w: np.ndarray,
+    line_point_w: np.ndarray,
+    line_dir_w: np.ndarray,
+    gamma: float,
+    core_radius: float,
+) -> np.ndarray:
+    """Return the induced velocity using a Lamb–Oseen-smoothed vortex line."""
+
+    r_vec = point_w - line_point_w
+    t_hat = unit(line_dir_w)
+    r_ax = np.dot(r_vec, t_hat) * t_hat
+    r_perp = r_vec - r_ax
+    r_mag = float(np.linalg.norm(r_perp))
+    if r_mag < 1e-6:
+        return np.zeros(3)
+
+    r_hat = r_perp / r_mag
+    theta_hat = np.cross(t_hat, r_hat)
+
+    v_theta = (gamma / (2.0 * np.pi * r_mag)) * (
+        1.0 - np.exp(-(r_mag * r_mag) / (core_radius * core_radius))
+    )
+    return v_theta * theta_hat
+
+
+def axial_decay_factor(axial_dist: float, Ld: float) -> float:
+    if Ld <= 0.0:
+        return 1.0
+    return float(np.exp(-max(0.0, axial_dist) / Ld))
+

--- a/src/formation_flight_pid_control/world.py
+++ b/src/formation_flight_pid_control/world.py
@@ -2,16 +2,23 @@
 
 from __future__ import annotations
 
-from typing import List, Optional, Tuple
+from typing import List
 
 import numpy as np
 
-from .airplane import Airplane6DoFLite, AirplaneState
+from .airplane import Airplane6DoFLite
 from .controllers import PIDFollower
 from .formation import build_formation
-from .geometry import AIRCRAFT_GEOMETRY_BODY, rotate_body_to_earth, rotate_earth_to_body, _normalized_quaternion
+from .geometry import rotate_body_to_earth, rotate_earth_to_body
 from .params import Params
 from .visualization import AircraftVisual
+from .wake import (
+    AircraftWake,
+    VortexBead,
+    axial_decay_factor,
+    lamb_oseen_induced_vel_at_point,
+    unit,
+)
 
 
 class World:
@@ -37,10 +44,178 @@ class World:
         
         # Extract airplanes for easier access
         self.airplanes = [aircraft.sim for aircraft in self.formation]
-        
+
         # Time tracking
         self.t = 0.0
-    
+
+        self._init_wake_state()
+
+    def _init_wake_state(self) -> None:
+        self._aircraft_wakes = {ac.sim: AircraftWake() for ac in self.formation}
+        self._wake_accum_dist = {ac.sim: 0.0 for ac in self.formation}
+
+    def _estimate_circulation(self, sim: Airplane6DoFLite) -> float:
+        quat = np.array([sim.state.pose.w, sim.state.pose.x, sim.state.pose.y, sim.state.pose.z])
+        vel_body = rotate_earth_to_body(quat, sim.state.velocity)
+        V = max(1e-3, float(np.linalg.norm(vel_body)))
+        u_body, v_body, w_body = vel_body
+        alpha = np.arctan2(w_body, u_body)
+        CL = self.params.CL0 + self.params.CL_alpha * alpha
+        CL = float(np.clip(CL, -self.params.CL_max, self.params.CL_max))
+        qbar = 0.5 * self.params.rho * V * V
+        L = CL * qbar * self.params.S_wing_ref_area
+        Gamma_tot = (L / (self.params.rho * V * self.params.b_span)) * self.params.wake_gamma_scale
+        return Gamma_tot
+
+    def _wingtip_world_positions(
+        self, sim: Airplane6DoFLite
+    ) -> tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray]:
+        quat = np.array([sim.state.pose.w, sim.state.pose.x, sim.state.pose.y, sim.state.pose.z])
+        ex_b = rotate_body_to_earth(quat, np.array([1.0, 0.0, 0.0]))
+        ey_b = rotate_body_to_earth(quat, np.array([0.0, 1.0, 0.0]))
+        cg_w = sim.state.position
+        half_span = 0.5 * self.params.b_span
+        left_tip_w = cg_w - ey_b * half_span
+        right_tip_w = cg_w + ey_b * half_span
+        return cg_w, left_tip_w, right_tip_w, ex_b
+
+    def _update_emit_wake(self, dt: float) -> None:
+        if not self.params.wake_enable:
+            return
+
+        for ac in self.formation:
+            sim = ac.sim
+            wake = self._aircraft_wakes[sim]
+            cg_w, left_tip_w, right_tip_w, xhat_w = self._wingtip_world_positions(sim)
+            Vmag = float(np.linalg.norm(sim.state.velocity))
+            if Vmag < 1e-2:
+                continue
+
+            Gamma_tot = self._estimate_circulation(sim)
+            Gamma_tip = 0.5 * Gamma_tot
+            gamma_left = +Gamma_tip
+            gamma_right = -Gamma_tip
+
+            self._wake_accum_dist[sim] += Vmag * dt
+            if self._wake_accum_dist[sim] >= self.params.wake_segment_length or not wake.left.beads:
+                self._wake_accum_dist[sim] = 0.0
+                wake.left.beads.insert(
+                    0,
+                    VortexBead(pos_w=left_tip_w.copy(), gamma=gamma_left, age=0.0),
+                )
+                wake.right.beads.insert(
+                    0,
+                    VortexBead(pos_w=right_tip_w.copy(), gamma=gamma_right, age=0.0),
+                )
+                if len(wake.left.beads) > self.params.wake_history_len:
+                    wake.left.beads.pop()
+                if len(wake.right.beads) > self.params.wake_history_len:
+                    wake.right.beads.pop()
+
+            for tip in (wake.left, wake.right):
+                for bead in tip.beads:
+                    bead.pos_w = bead.pos_w + sim.state.velocity * dt
+                    bead.age += dt
+                    if self.params.wake_decay_time > 0.0:
+                        bead.gamma *= np.exp(-dt / self.params.wake_decay_time)
+                    ax = np.dot((bead.pos_w - cg_w), xhat_w)
+                    bead.gamma *= axial_decay_factor(ax, self.params.wake_axial_decay_len)
+
+    def _halfspan_sample_points_world(
+        self, sim: Airplane6DoFLite
+    ) -> tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray, np.ndarray]:
+        quat = np.array([sim.state.pose.w, sim.state.pose.x, sim.state.pose.y, sim.state.pose.z])
+        xhat_w = rotate_body_to_earth(quat, np.array([1.0, 0.0, 0.0]))
+        yhat_w = rotate_body_to_earth(quat, np.array([0.0, 1.0, 0.0]))
+        cg_w = sim.state.position
+        half_span = 0.5 * self.params.b_span * 0.9
+        left_w = cg_w - yhat_w * half_span
+        right_w = cg_w + yhat_w * half_span
+        return cg_w, xhat_w, yhat_w, left_w, right_w
+
+    def _induced_velocity_from_all_wakes(
+        self, receiver_sim: Airplane6DoFLite, point_w: np.ndarray
+    ) -> np.ndarray:
+        if not self.params.wake_enable:
+            return np.zeros(3)
+
+        v_ind = np.zeros(3)
+        rc = self.params.wake_core_radius
+        for ac in self.formation:
+            src_sim = ac.sim
+            if src_sim is receiver_sim:
+                continue
+            wake = self._aircraft_wakes[src_sim]
+            for tip in (wake.left, wake.right):
+                beads = tip.beads
+                if not beads:
+                    continue
+                for i, bead in enumerate(beads):
+                    if i + 1 < len(beads):
+                        next_bead = beads[i + 1]
+                        line_dir = unit(next_bead.pos_w - bead.pos_w)
+                        if np.linalg.norm(line_dir) < 1e-6:
+                            _, _, _, xhat_w = self._wingtip_world_positions(src_sim)
+                            line_dir = xhat_w
+                    else:
+                        _, _, _, xhat_w = self._wingtip_world_positions(src_sim)
+                        line_dir = xhat_w
+                    v_ind += lamb_oseen_induced_vel_at_point(
+                        point_w, bead.pos_w, line_dir, bead.gamma, rc
+                    )
+        return v_ind
+
+    def _wake_forces_moments_on(
+        self, receiver_sim: Airplane6DoFLite
+    ) -> tuple[np.ndarray, np.ndarray]:
+        if not self.params.wake_enable:
+            return np.zeros(3), np.zeros(3)
+
+        cg_w, _, _, left_w, right_w = self._halfspan_sample_points_world(receiver_sim)
+
+        v_left_w = self._induced_velocity_from_all_wakes(receiver_sim, left_w)
+        v_right_w = self._induced_velocity_from_all_wakes(receiver_sim, right_w)
+
+        quat = np.array([receiver_sim.state.pose.w, receiver_sim.state.pose.x, receiver_sim.state.pose.y, receiver_sim.state.pose.z])
+        v_body = rotate_earth_to_body(quat, receiver_sim.state.velocity)
+        Vmag = max(1e-3, float(np.linalg.norm(v_body)))
+
+        v_left_b = rotate_earth_to_body(quat, v_left_w)
+        v_right_b = rotate_earth_to_body(quat, v_right_w)
+
+        w_left = v_left_b[2]
+        w_right = v_right_b[2]
+        d_alpha_left = -w_left / Vmag
+        d_alpha_right = -w_right / Vmag
+
+        qbar = 0.5 * self.params.rho * Vmag * Vmag
+        S_half = 0.5 * self.params.S_wing_ref_area
+
+        dL_left = qbar * S_half * self.params.CL_alpha * d_alpha_left
+        dL_right = qbar * S_half * self.params.CL_alpha * d_alpha_right
+
+        V_hat_body = v_body / Vmag
+        lift_dir_b = np.array([V_hat_body[2], 0.0, -V_hat_body[0]])
+        norm_lift = float(np.linalg.norm(lift_dir_b))
+        if norm_lift < 1e-6:
+            lift_dir_b = np.array([0.0, 0.0, -1.0])
+        else:
+            lift_dir_b = lift_dir_b / norm_lift
+
+        left_arm_b = rotate_earth_to_body(quat, left_w - cg_w)
+        right_arm_b = rotate_earth_to_body(quat, right_w - cg_w)
+
+        F_left_b = dL_left * lift_dir_b
+        F_right_b = dL_right * lift_dir_b
+
+        M_left_b = np.cross(left_arm_b, F_left_b)
+        M_right_b = np.cross(right_arm_b, F_right_b)
+
+        F_extra = F_left_b + F_right_b
+        M_extra = M_left_b + M_right_b
+
+        return F_extra, M_extra
+
     def simulation_step(self, dt: float) -> None:
         """Execute a single simulation step for all aircraft.
         
@@ -53,14 +228,27 @@ class World:
         leader.sim.step(u_leader, dt)
         leader.throttle_history.append(u_leader[0])
 
-        # Follower control
+        self._update_emit_wake(dt)
+
         for follower, target in zip(self.formation[1:], self.formation[:-1]):
             if follower.pid is None:
                 raise ValueError("Follower missing PID controller")
-            u_cmd, force, moment = follower.pid.pilot_follower(
+            u_cmd, force_pid, moment_pid = follower.pid.pilot_follower(
                 self.t, follower.sim.state, target.sim.state, dt
             )
-            follower.sim.step(u_cmd, dt, ext_F_body=force, ext_M_body=moment)
+            F_wake, M_wake = self._wake_forces_moments_on(follower.sim)
+
+            F_total = np.zeros(3)
+            M_total = np.zeros(3)
+            if force_pid is not None:
+                F_total += force_pid
+            if moment_pid is not None:
+                M_total += moment_pid
+
+            F_total += F_wake
+            M_total += M_wake
+
+            follower.sim.step(u_cmd, dt, ext_F_body=F_total, ext_M_body=M_total)
             follower.throttle_history.append(u_cmd[0])
 
         self.t += dt


### PR DESCRIPTION
## Summary
- add wake vortex data structures and helpers using a Lamb–Oseen smoothing model
- extend world simulation to emit, convect, and decay wingtip vortices and apply induced lift/roll loads to followers
- introduce tunable wake parameters and updated geometry defaults in the global Params

## Testing
- python -m compileall src

------
https://chatgpt.com/codex/tasks/task_e_68e2a3d2f668832bad8985303cfaf538